### PR TITLE
Fix Timer Reset on Page Change (#27)

### DIFF
--- a/src/components/QuestionBox/QuestionBox.jsx
+++ b/src/components/QuestionBox/QuestionBox.jsx
@@ -52,17 +52,22 @@ const QuestionBox = (props) => {
             checkAnswer(selectedAns)
             setNext(next + 1)
             setSelectedAns('')
+            localStorage.setItem('timer',30)
         }
         setAnswerList([...answerList, { 'question': question, 'options': options[0], 'id': `id${next}`, 'category': category, 'myAnswer': selectedAns, 'rightAnswer': options[1] }])
     }
 
     // for reverse timer
-    const [timer, setTimer] = useState(30)
+    const [timer, setTimer] = useState(()=>{
+        const savedTimer = localStorage.getItem('timer')
+        return savedTimer? parseInt(savedTimer):30
+    })
 
     useEffect(() => {
         let myInterval = setInterval(() => {
             if (timer > 0) {
                 setTimer(timer - 1)
+                localStorage.setItem('timer',timer-1)
             } else {
                 setNext(next + 1)
             }

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -13,6 +13,7 @@ const Home = () => {
     const handleSubmit = (e) => {
         e.preventDefault();
         const { number, category, difficulty, type } = formData
+        localStorage.setItem('timer',30)
         setUrl(`https://opentdb.com/api.php?amount=${number}&category=${category}&difficulty=${difficulty}&type=${type}`, fetchQuestions(url))
         setLoading(true)
     }


### PR DESCRIPTION
### Pull Request Description: Fix Timer Persistence Across Page Changes

**Issue Addressed:** #27  
This pull request resolves an issue where changing to a different page like about page would reset the timer, allowing users to extend their time. This behavior compromised the intended experience by letting users bypass the timer limit.

**Solution Implemented:**  
To ensure that the timer persists across page navigations, the following adjustments were made:
- **Local Storage Integration**: The timer value is now stored in `localStorage` and is continuously updated every second. This setup allows the timer to persist even when the user navigates to a different page and then returns to the quiz.

**Code Changes:**
- Added `localStorage` to manage and persist the timer state across page changes.
- Updated the timer in `localStorage` every second within the `useEffect` hook.
- Modified the `handleNextQuestion` function to reset the timer to 30 seconds and store the updated value in `localStorage`.
